### PR TITLE
Fix issue with gui voiding items.

### DIFF
--- a/src/me/zombie_striker/lobbyapi/Main.java
+++ b/src/me/zombie_striker/lobbyapi/Main.java
@@ -700,6 +700,7 @@ public class Main extends JavaPlugin implements Listener {
 						}
 					event.setCancelled(true);
 				}
+				event.setCancelled(true);
 			}
 		}
 	}


### PR DESCRIPTION
The InventoryClickEvent was not cancelling correctly, you could drag & drop items from your inventory into the LobbyAPI menu, then when you closed the LobbyAPI menu -- they're gone into the void.

Video detailing bug: https://youtu.be/nc36vhynTGg

This fix correctly cancels the InventoryClickEvent, and solves the problem.